### PR TITLE
Updated metadata.json to allow installation on gnome 3.8

### DIFF
--- a/extra-panels@darkxst.feathertop.org/metadata.json
+++ b/extra-panels@darkxst.feathertop.org/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.5.90","3.5.92", "3.6"],
+	"shell-version": ["3.5.90","3.5.92", "3.6", "3.8"],
 	"uuid": "extra-panels@darkxst.feathertop.org",
 	"settings-schema": "org.gnome.shell.extensions.extra-panels",
 	"gettext-domain": "multiple-monitor-panels", 

--- a/extra-panels@darkxst.feathertop.org/metadata.json
+++ b/extra-panels@darkxst.feathertop.org/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["3.5.90","3.5.92", "3.6", "3.8"],
+	"shell-version": ["3.5.90","3.5.92", "3.6", "3.8", "3.10"],
 	"uuid": "extra-panels@darkxst.feathertop.org",
 	"settings-schema": "org.gnome.shell.extensions.extra-panels",
 	"gettext-domain": "multiple-monitor-panels", 


### PR DESCRIPTION
It seems to work fine, but it has not been thoroughly tested.
